### PR TITLE
Replace deprecated Mesa cache env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive \
     DISPLAY=:1 \
     LIBGL_ALWAYS_SOFTWARE=1 \
-    MESA_GLSL_CACHE_DIR=/tmp/.mesa-cache
+    MESA_SHADER_CACHE_DIR=/tmp/.mesa-cache
 
 # Allow pinning DeepDrill
 ARG DEEPDRILL_REPO=https://github.com/dirkwhoffmann/DeepDrill.git


### PR DESCRIPTION
## Summary
- switch Dockerfile to use `MESA_SHADER_CACHE_DIR` instead of deprecated `MESA_GLSL_CACHE_DIR` to avoid Mesa warnings

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b585d39eb48332901a646c9944cc12