### PR TITLE
Suppress joystick warnings during video rendering

### DIFF
--- a/image/deepdrill-cmd
+++ b/image/deepdrill-cmd
@@ -40,6 +40,10 @@ fi
 
 mkdir -p "$OUT"
 
+# Disable SDL joystick and gamecontroller probing to suppress noisy /dev/input/js0 warnings
+export SDL_JOYSTICK_IGNORE_DEVICES=all
+export SDL_GAMECONTROLLER_IGNORE_DEVICES=all
+
 # Run deepmake non-interactively; always auto-confirm
 if [[ ${DEEPDRILL_ASSUME_YES:-$ASSUME_YES} -eq 1 ]]; then
   # Send a single 'y' to confirm; avoids SIGPIPE with 'yes' under pipefail


### PR DESCRIPTION
## Summary
- Avoid SDL's joystick and gamecontroller probing to suppress `/dev/input/js0` warnings during rendering

## Testing
- `image/deepdrill-cmd -c smoke.ini -o out` *(fails: /opt/DeepDrill/build/deepmake: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b612df66c883329d7a58139b45f30f